### PR TITLE
fix: DDC/CI で優先モニタの実表示入力を見て LGTV の勝手な切替を防止

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
   - Preferred monitor 以外のモニタ変化でも Sync が走ることを期待。この動作を破壊しないこと。
   - ネットワーク例外（WebSocket/HttpRequest/Socket）はそのスナップショットを捨て、ループは継続。
 - **LGTV 同期**: オンライン/オフライン双方で Target/Fallback を自動切替。既に目標入力なら冪等スキップ。
+- **入力ソース判定（DDC/CI）**: 優先モニタが「今このPCを映しているか」は列挙有無では判別できない（USB-C/KVM モニタは別PC表示中も DP リンクを維持するため）。`IPreferredInputSourceProbe`（Windows: `DdcInputSourceProbe` が VCP 0x60 を読む）で都度判定し、`ThisPc`→online 扱い / `OtherSource`→offline 扱い / `Unknown`→列挙ベースへフォールバック、として同期判定に反映する。**この判定は同期の度に都度実行すること**（Mac への表示切替はディスプレイイベントを発火しないため、スナップショットに焼き込むと定期同期が誤って TV を奪う）。DDC は稀に失敗するのでリトライ＋直近確定値の保持で安定させる。
 - **TLS/ClientKey**:
   - webOS の自己署名証明書対策として `DefaultWebSocketTransport` は wss 証明書検証を緩和する仕様を維持する。
   - `clientKey` / `preferredTvUsn` は sidecar `state.json`（Win: `%LOCALAPPDATA%/LgtvSwitcher/state.json`、Mac: `~/Library/Application Support/LgtvSwitcher/state.json`）に永続化。`appsettings.json` には置かない。

--- a/README.md
+++ b/README.md
@@ -49,9 +49,26 @@ PCとMacで1台の高性能モニター（例：Dell U2725QE）を共有して�
     // 監視対象とするモニターの「フレンドリーネーム」
     // "DELL U2725QE" など。部分一致で判定されます。
     // この名前が空だと、TVの切り替えは実行されません。
-    "PreferredMonitorName": ""
+    "PreferredMonitorName": "",
+
+    // 優先モニタが「このPCを映している」とみなす DDC/CI VCP 0x60(Input Source) の値一覧（10進）。
+    // 15=0x0F(DisplayPort), 17=0x11(HDMI), DELL U2725QE の USB-C は 25=0x19。
+    // 既定は [15]（DisplayPort）。空配列にすると DDC 判定を使わず従来の列挙ベースにフォールバック。
+    "PreferredMonitorThisPcInputSources": [ 15 ]
   }
 }
+```
+
+### なぜ DDC/CI で入力ソースを見るのか
+
+Dell U2725QE のような USB-C/KVM ハブ搭載モニタは、**表示ソースを別PC(Mac の USB-C 等)へ切り替えても、Windows への DisplayPort リンクを生かしたまま**にします。そのため Windows の列挙(GDI/WMI)ではモニタが常に「接続中」に見え、「今このPCを映しているか」を判別できません（このツールが TV を勝手に奪ってしまう原因でした）。
+
+そこで **DDC/CI（VCP 0x60 = Input Source）でモニタ本体に「今どの入力を映しているか」を直接問い合わせ**、優先モニタが `PreferredMonitorThisPcInputSources` の入力（既定は DisplayPort）を映しているときだけ TV を `TargetInputId` に切り替えます。別ソース(Mac)を映している間は TV に一切触れません。DDC は稀に読み取りに失敗するため、短時間リトライと直近確定値の保持で判定を安定させています。
+
+対応値の確認は次のコマンドで行えます（優先モニタの現在入力ソースを表示）:
+
+```powershell
+dotnet run --project src/LGTVSwitcher.Daemon.Windows -- probe-input
 ```
 
 **`PreferredMonitorName` の確認方法:**

--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ PCとMacで1台の高性能モニター（例：Dell U2725QE）を共有して�
     // この名前が空だと、TVの切り替えは実行されません。
     "PreferredMonitorName": "",
 
-    // 優先モニタが「このPCを映している」とみなす DDC/CI VCP 0x60(Input Source) の値一覧（10進）。
-    // 15=0x0F(DisplayPort), 17=0x11(HDMI), DELL U2725QE の USB-C は 25=0x19。
-    // 既定は [15]（DisplayPort）。空配列にすると DDC 判定を使わず従来の列挙ベースにフォールバック。
-    "PreferredMonitorThisPcInputSources": [ 15 ]
+    // 優先モニタが「このPCを映している」とみなす映像入力インターフェース名の一覧。
+    // 使える名前: "DisplayPort"("DP") / "HDMI" / "USB-C"("USB"/"Thunderbolt") / "DVI" / "VGA"。
+    // 別モニタで値が異なる場合は生の値 "0x1B" / "27" も指定可。
+    // 既定は ["DisplayPort"]。空配列にすると DDC 判定を使わず従来の列挙ベースにフォールバック。
+    "PreferredMonitorThisPcInputSources": [ "DisplayPort" ]
   }
 }
 ```

--- a/src/LGTVSwitcher.Core/Display/IPreferredInputSourceProbe.cs
+++ b/src/LGTVSwitcher.Core/Display/IPreferredInputSourceProbe.cs
@@ -1,0 +1,43 @@
+namespace LGTVSwitcher.Core.Display;
+
+/// <summary>
+/// 優先モニタが「今このPCの映像入力を映しているか」を表す状態。
+/// </summary>
+/// <remarks>
+/// DELL U2725QE のようなマルチ入力/KVMモニタは、表示ソースを別PC（例: Mac の USB-C）へ
+/// 切り替えても、Windows への DisplayPort リンクを生かしたままにする。そのため
+/// <see cref="MonitorSnapshot"/> の列挙有無だけでは「このPCを映しているか」を判別できない。
+/// この状態は DDC/CI（VCP 0x60 = Input Source）等の別経路で取得する。
+/// </remarks>
+public enum PreferredInputSource
+{
+    /// <summary>判定できなかった（プローブ非対応・読み取り失敗・未接続など）。</summary>
+    Unknown = 0,
+
+    /// <summary>優先モニタはこのPCの入力（例: DisplayPort）を映している。</summary>
+    ThisPc = 1,
+
+    /// <summary>優先モニタは別ソースの入力（例: Mac の USB-C）を映している。</summary>
+    OtherSource = 2,
+}
+
+/// <summary>
+/// 優先モニタが今どの映像入力を映しているかを問い合わせるプローブ。
+/// OS 依存の実装（Windows は DDC/CI）を注入する。
+/// </summary>
+public interface IPreferredInputSourceProbe
+{
+    /// <summary>
+    /// 優先モニタの現在の入力ソース状態を返す。判定不能なら <see cref="PreferredInputSource.Unknown"/>。
+    /// </summary>
+    PreferredInputSource Probe();
+}
+
+/// <summary>
+/// 常に <see cref="PreferredInputSource.Unknown"/> を返す既定プローブ。
+/// DDC を持たない環境（macOS など）や未設定時に使用し、既存の列挙ベース判定へフォールバックさせる。
+/// </summary>
+public sealed class NullPreferredInputSourceProbe : IPreferredInputSourceProbe
+{
+    public PreferredInputSource Probe() => PreferredInputSource.Unknown;
+}

--- a/src/LGTVSwitcher.Core/Display/MonitorInputSourceCatalog.cs
+++ b/src/LGTVSwitcher.Core/Display/MonitorInputSourceCatalog.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LGTVSwitcher.Core.Display;
+
+/// <summary>
+/// モニタの映像入力インターフェース名と DDC/CI VCP 0x60(Input Source) の値を相互変換するカタログ。
+/// </summary>
+/// <remarks>
+/// 設定を数値ではなく <c>"DisplayPort"</c> / <c>"HDMI"</c> / <c>"USB-C"</c> のような名前で書けるようにする。
+/// DisplayPort/HDMI/DVI/VGA は MCCS 標準コード。USB-C(0x19) はベンダ依存で、値は DELL U2725QE 実測。
+/// 別モニタで異なる場合は名前ではなく生の値（<c>"0x1B"</c> や <c>"27"</c>）を指定できる。
+/// </remarks>
+public static class MonitorInputSourceCatalog
+{
+    // 名前 → VCP 0x60 コード（大文字小文字・別名を吸収）。
+    private static readonly IReadOnlyDictionary<string, int> NameToCode = new Dictionary<string, int>(System.StringComparer.OrdinalIgnoreCase)
+    {
+        ["DisplayPort"] = 0x0F,
+        ["DisplayPort1"] = 0x0F,
+        ["DP"] = 0x0F,
+        ["DP1"] = 0x0F,
+        ["DisplayPort2"] = 0x10,
+        ["DP2"] = 0x10,
+        ["HDMI"] = 0x11,
+        ["HDMI1"] = 0x11,
+        ["HDMI2"] = 0x12,
+        ["USB-C"] = 0x19,
+        ["USBC"] = 0x19,
+        ["USB"] = 0x19,
+        ["Thunderbolt"] = 0x19,
+        ["TB"] = 0x19,
+        ["DVI"] = 0x03,
+        ["DVI1"] = 0x03,
+        ["DVI2"] = 0x04,
+        ["VGA"] = 0x01,
+    };
+
+    /// <summary>
+    /// 入力インターフェース名または生の値（<c>"0x19"</c>/<c>"25"</c>）を VCP 0x60 コードへ解決する。
+    /// </summary>
+    public static bool TryResolve(string? value, out int code)
+    {
+        code = 0;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var trimmed = value.Trim();
+
+        if (NameToCode.TryGetValue(trimmed, out code))
+        {
+            return true;
+        }
+
+        if (trimmed.StartsWith("0x", System.StringComparison.OrdinalIgnoreCase))
+        {
+            return int.TryParse(trimmed.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out code);
+        }
+
+        return int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out code);
+    }
+}

--- a/src/LGTVSwitcher.Core/LgTv/LgTvSwitcherOptions.cs
+++ b/src/LGTVSwitcher.Core/LgTv/LgTvSwitcherOptions.cs
@@ -46,4 +46,13 @@ public sealed class LgTvSwitcherOptions
     /// LG TV の切り替えをトリガーするモニタのフレンドリ名（またはデバイス名）。
     /// </summary>
     public string PreferredMonitorName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 優先モニタが「このPCを映している」とみなす DDC/CI VCP 0x60(Input Source) の値一覧。
+    /// マルチ入力モニタ（例: DELL U2725QE）で、表示ソースが別PC(Mac の USB-C 等)へ移っても
+    /// DisplayPort リンクは生き続けるため、列挙有無では判別できない。この値で実際の表示入力を判定する。
+    /// 既定は DisplayPort(0x0F=15)。空にすると DDC 判定を使わず従来の列挙ベースにフォールバックする。
+    /// （参考: 0x0F=DisplayPort, 0x11=HDMI, DELL U2725QE の USB-C は 0x19。）
+    /// </summary>
+    public int[]? PreferredMonitorThisPcInputSources { get; set; } = new[] { 0x0F };
 }

--- a/src/LGTVSwitcher.Core/LgTv/LgTvSwitcherOptions.cs
+++ b/src/LGTVSwitcher.Core/LgTv/LgTvSwitcherOptions.cs
@@ -48,11 +48,12 @@ public sealed class LgTvSwitcherOptions
     public string PreferredMonitorName { get; set; } = string.Empty;
 
     /// <summary>
-    /// 優先モニタが「このPCを映している」とみなす DDC/CI VCP 0x60(Input Source) の値一覧。
+    /// 優先モニタが「このPCを映している」とみなす映像入力インターフェース名の一覧。
     /// マルチ入力モニタ（例: DELL U2725QE）で、表示ソースが別PC(Mac の USB-C 等)へ移っても
-    /// DisplayPort リンクは生き続けるため、列挙有無では判別できない。この値で実際の表示入力を判定する。
-    /// 既定は DisplayPort(0x0F=15)。空にすると DDC 判定を使わず従来の列挙ベースにフォールバックする。
-    /// （参考: 0x0F=DisplayPort, 0x11=HDMI, DELL U2725QE の USB-C は 0x19。）
+    /// DisplayPort リンクは生き続けるため、列挙有無では判別できない。この入力で実際の表示ソースを判定する。
+    /// 名前は "DisplayPort" / "HDMI" / "USB-C" など（<see cref="Display.MonitorInputSourceCatalog"/> 参照）。
+    /// 別モニタで値が異なる場合は生の値 "0x1B" / "27" も指定可。
+    /// 既定は "DisplayPort"。空にすると DDC 判定を使わず従来の列挙ベースにフォールバックする。
     /// </summary>
-    public int[]? PreferredMonitorThisPcInputSources { get; set; } = new[] { 0x0F };
+    public string[]? PreferredMonitorThisPcInputSources { get; set; } = new[] { "DisplayPort" };
 }

--- a/src/LGTVSwitcher.Core/Workers/DisplaySyncWorker.cs
+++ b/src/LGTVSwitcher.Core/Workers/DisplaySyncWorker.cs
@@ -19,6 +19,7 @@ public sealed class DisplaySyncWorker : BackgroundService
 
     private readonly IDisplaySnapshotProvider _snapshotProvider;
     private readonly ILgTvController _lgTvController;
+    private readonly IPreferredInputSourceProbe _inputSourceProbe;
     private readonly ILogger<DisplaySyncWorker> _logger;
     private readonly LgTvSwitcherOptions _options;
     private readonly string[] _allowedCurrentInputIds;
@@ -28,11 +29,13 @@ public sealed class DisplaySyncWorker : BackgroundService
     public DisplaySyncWorker(
         IDisplaySnapshotProvider snapshotProvider,
         ILgTvController lgTvController,
+        IPreferredInputSourceProbe inputSourceProbe,
         IOptions<LgTvSwitcherOptions> options,
         ILogger<DisplaySyncWorker> logger)
     {
         _snapshotProvider = snapshotProvider;
         _lgTvController = lgTvController;
+        _inputSourceProbe = inputSourceProbe;
         _logger = logger;
         _options = options.Value;
         _allowedCurrentInputIds = _options.AllowedCurrentInputIds?
@@ -144,12 +147,23 @@ public sealed class DisplaySyncWorker : BackgroundService
             return;
         }
 
-        var targetInput = GetTargetInput(snapshot);
+        // 優先モニタが「今このPCの入力を映しているか」を DDC/CI で都度確認する。
+        // マルチ入力モニタは表示を別PC(Mac)へ移してもリンクを維持するため、列挙有無だけでは判別できない。
+        var showing = _inputSourceProbe.Probe();
+        var effectiveOnline = showing switch
+        {
+            PreferredInputSource.ThisPc => true,
+            PreferredInputSource.OtherSource => false,
+            _ => snapshot.PreferredMonitorOnline,
+        };
+
+        var targetInput = effectiveOnline ? _options.TargetInputId : _options.FallbackInputId;
         if (string.IsNullOrWhiteSpace(targetInput))
         {
             _logger.LogInformation(
-                "No input mapping configured for preferred monitor state {State}; skipping.",
-                snapshot.PreferredMonitorOnline);
+                "No input mapping configured for preferred monitor state {State} (input source={Source}); skipping.",
+                effectiveOnline,
+                showing);
             return;
         }
 
@@ -190,7 +204,7 @@ public sealed class DisplaySyncWorker : BackgroundService
             return;
         }
 
-        _logger.LogInformation("Switching LG TV input to {Input} (preferred monitor online = {State})", targetInput, snapshot.PreferredMonitorOnline);
+        _logger.LogInformation("Switching LG TV input to {Input} (preferred monitor online = {State}, input source = {Source})", targetInput, effectiveOnline, showing);
         await _lgTvController.SwitchInputAsync(targetInput, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/LGTVSwitcher.Daemon.Windows/DaemonCommands.cs
+++ b/src/LGTVSwitcher.Daemon.Windows/DaemonCommands.cs
@@ -1,5 +1,6 @@
 using ConsoleAppFramework;
 
+using LGTVSwitcher.Core.Display;
 using LGTVSwitcher.Core.LgTv;
 using LGTVSwitcher.Core.LgWebOs;
 
@@ -17,6 +18,17 @@ public sealed class DaemonCommands
     {
         using var host = DaemonHost.Build(Array.Empty<string>());
         await host.RunAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>優先モニタの現在の入力ソースを DDC/CI で読む（検証用POC）</summary>
+    [Command("probe-input")]
+    public Task ProbeInput()
+    {
+        using var host = DaemonHost.Build(Array.Empty<string>());
+        var probe = host.Services.GetRequiredService<IPreferredInputSourceProbe>();
+        var result = probe.Probe();
+        Console.WriteLine($"PreferredInputSource = {result}");
+        return Task.CompletedTask;
     }
 
     /// <summary>SSDP で TV を検出し、必要なら PreferredTvUsn を保存</summary>

--- a/src/LGTVSwitcher.Daemon.Windows/DaemonHost.cs
+++ b/src/LGTVSwitcher.Daemon.Windows/DaemonHost.cs
@@ -59,6 +59,7 @@ internal static class DaemonHost
         services.AddSingleton<IMonitorEnumerator, Win32MonitorEnumerator>();
         services.AddSingleton<WindowsMonitorDetector>();
         services.AddSingleton<IDisplaySnapshotProvider, WindowsDisplaySnapshotProvider>();
+        services.AddSingleton<IPreferredInputSourceProbe, DdcInputSourceProbe>();
 
         services.AddHostedService<DisplaySyncWorker>();
     }

--- a/src/LGTVSwitcher.Daemon.Windows/DisplayDetection/Windows/DdcInputSourceProbe.cs
+++ b/src/LGTVSwitcher.Daemon.Windows/DisplayDetection/Windows/DdcInputSourceProbe.cs
@@ -34,6 +34,9 @@ public sealed class DdcInputSourceProbe : IPreferredInputSourceProbe
     private readonly LgTvSwitcherOptions _options;
     private readonly ILogger<DdcInputSourceProbe> _logger;
 
+    // 「このPCを映している」とみなす VCP 0x60 コード（設定の名前を解決したもの、下位バイトで比較）。
+    private readonly int[] _thisPcCodes;
+
     // 直近に確定した状態。全リトライが失敗したときにこれを維持し、一過性の失敗で判定が揺れないようにする。
     private volatile PreferredInputSource _lastKnown = PreferredInputSource.Unknown;
 
@@ -41,6 +44,32 @@ public sealed class DdcInputSourceProbe : IPreferredInputSourceProbe
     {
         _options = options.Value;
         _logger = logger;
+        _thisPcCodes = ResolveThisPcCodes(_options.PreferredMonitorThisPcInputSources);
+    }
+
+    private int[] ResolveThisPcCodes(string[]? names)
+    {
+        if (names is null || names.Length == 0)
+        {
+            return Array.Empty<int>();
+        }
+
+        var codes = new List<int>(names.Length);
+        foreach (var name in names)
+        {
+            if (MonitorInputSourceCatalog.TryResolve(name, out var code))
+            {
+                codes.Add(code & 0xFF);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "PreferredMonitorThisPcInputSources の値 '{Value}' を入力ソースへ解決できません（例: DisplayPort / HDMI / USB-C / 0x1B）。無視します。",
+                    name);
+            }
+        }
+
+        return codes.ToArray();
     }
 
     public PreferredInputSource Probe()
@@ -50,10 +79,9 @@ public sealed class DdcInputSourceProbe : IPreferredInputSourceProbe
             return PreferredInputSource.Unknown;
         }
 
-        var thisPcSources = _options.PreferredMonitorThisPcInputSources;
-        if (thisPcSources is null || thisPcSources.Length == 0)
+        if (_thisPcCodes.Length == 0)
         {
-            // DDC 判定が無効化されている（従来の列挙ベースへフォールバック）。
+            // DDC 判定が無効化されている（設定が空、または全て解決不能）。従来の列挙ベースへフォールバック。
             return PreferredInputSource.Unknown;
         }
 
@@ -69,11 +97,11 @@ public sealed class DdcInputSourceProbe : IPreferredInputSourceProbe
             if (current is not null)
             {
                 // 一部モニタは上位バイトに付随値を載せるため、入力コードは下位バイトで比較する。
-                var code = current.Value & 0xFF;
+                var code = (int)(current.Value & 0xFF);
                 var result = PreferredInputSource.OtherSource;
-                foreach (var thisPc in thisPcSources)
+                foreach (var thisPc in _thisPcCodes)
                 {
-                    if ((thisPc & 0xFF) == code)
+                    if (thisPc == code)
                     {
                         result = PreferredInputSource.ThisPc;
                         break;

--- a/src/LGTVSwitcher.Daemon.Windows/DisplayDetection/Windows/DdcInputSourceProbe.cs
+++ b/src/LGTVSwitcher.Daemon.Windows/DisplayDetection/Windows/DdcInputSourceProbe.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Threading;
+
+using LGTVSwitcher.Core.Display;
+using LGTVSwitcher.Core.LgTv;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace LGTVSwitcher.Daemon.Windows.DisplayDetection;
+
+/// <summary>
+/// DDC/CI (VCP 0x60 = Input Source) を用いて、優先モニタが今どの映像入力を映しているかを判定するプローブ。
+/// </summary>
+/// <remarks>
+/// DELL U2725QE 等の USB-C/KVM モニタは、表示を Mac へ切り替えても Windows への DisplayPort リンクを
+/// 生かしたままにする。よって GDI/WMI の列挙では「このPCを映しているか」を判別できない。
+/// 本プローブは物理モニタへ DDC/CI で問い合わせ、現在選択中の入力ソースが「このPC」の入力か判定する。
+/// 判定は同期呼び出し（DDC は数十ms）で、同期ループの判定時に都度実行する想定。
+/// </remarks>
+[SupportedOSPlatform("windows")]
+[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+public sealed class DdcInputSourceProbe : IPreferredInputSourceProbe
+{
+    private const byte VcpInputSource = 0x60;
+
+    // DDC/CI は I2C 越しのため単発で失敗することがある。短時間リトライで平滑化する。
+    private const int ReadAttempts = 3;
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(120);
+
+    private readonly LgTvSwitcherOptions _options;
+    private readonly ILogger<DdcInputSourceProbe> _logger;
+
+    // 直近に確定した状態。全リトライが失敗したときにこれを維持し、一過性の失敗で判定が揺れないようにする。
+    private volatile PreferredInputSource _lastKnown = PreferredInputSource.Unknown;
+
+    public DdcInputSourceProbe(IOptions<LgTvSwitcherOptions> options, ILogger<DdcInputSourceProbe> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public PreferredInputSource Probe()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return PreferredInputSource.Unknown;
+        }
+
+        var thisPcSources = _options.PreferredMonitorThisPcInputSources;
+        if (thisPcSources is null || thisPcSources.Length == 0)
+        {
+            // DDC 判定が無効化されている（従来の列挙ベースへフォールバック）。
+            return PreferredInputSource.Unknown;
+        }
+
+        var preferredName = _options.PreferredMonitorName;
+        if (string.IsNullOrWhiteSpace(preferredName))
+        {
+            return PreferredInputSource.Unknown;
+        }
+
+        for (var attempt = 0; attempt < ReadAttempts; attempt++)
+        {
+            var current = TryReadPreferredInputSource(preferredName);
+            if (current is not null)
+            {
+                // 一部モニタは上位バイトに付随値を載せるため、入力コードは下位バイトで比較する。
+                var code = current.Value & 0xFF;
+                var result = PreferredInputSource.OtherSource;
+                foreach (var thisPc in thisPcSources)
+                {
+                    if ((thisPc & 0xFF) == code)
+                    {
+                        result = PreferredInputSource.ThisPc;
+                        break;
+                    }
+                }
+
+                _logger.LogDebug(
+                    "DDC input source of '{Monitor}' = 0x{Code:X2} ({Result}).", preferredName, code, result);
+                _lastKnown = result;
+                return result;
+            }
+
+            if (attempt < ReadAttempts - 1)
+            {
+                Thread.Sleep(RetryDelay);
+            }
+        }
+
+        // 全リトライ失敗。直近の確定値があればそれを維持（一過性の DDC 失敗で TV を奪わないため）。
+        if (_lastKnown != PreferredInputSource.Unknown)
+        {
+            _logger.LogDebug("DDC read failed for '{Monitor}'; reusing last known {State}.", preferredName, _lastKnown);
+            return _lastKnown;
+        }
+
+        return PreferredInputSource.Unknown;
+    }
+
+    private uint? TryReadPreferredInputSource(string preferredName)
+    {
+        var handles = new List<IntPtr>();
+        NativeMethods.EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero, (h, _, _, _) => { handles.Add(h); return true; }, IntPtr.Zero);
+
+        foreach (var hMonitor in handles)
+        {
+            if (!NativeMethods.GetNumberOfPhysicalMonitorsFromHMONITOR(hMonitor, out var count) || count == 0)
+            {
+                continue;
+            }
+
+            var monitors = new NativeMethods.PHYSICAL_MONITOR[count];
+            if (!NativeMethods.GetPhysicalMonitorsFromHMONITOR(hMonitor, count, monitors))
+            {
+                continue;
+            }
+
+            try
+            {
+                foreach (var monitor in monitors)
+                {
+                    var description = monitor.szPhysicalMonitorDescription ?? string.Empty;
+                    if (description.IndexOf(preferredName, StringComparison.OrdinalIgnoreCase) < 0)
+                    {
+                        continue;
+                    }
+
+                    if (NativeMethods.GetVCPFeatureAndVCPFeatureReply(
+                            monitor.hPhysicalMonitor, VcpInputSource, out _, out var currentValue, out _))
+                    {
+                        return currentValue;
+                    }
+
+                    _logger.LogDebug(
+                        "DDC VCP 0x60 read failed for '{Description}' (err={Error}).",
+                        description,
+                        Marshal.GetLastWin32Error());
+                }
+            }
+            finally
+            {
+                NativeMethods.DestroyPhysicalMonitors(count, monitors);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/LGTVSwitcher.Daemon.Windows/DisplayDetection/Windows/NativeMethods.cs
+++ b/src/LGTVSwitcher.Daemon.Windows/DisplayDetection/Windows/NativeMethods.cs
@@ -65,6 +65,33 @@ internal static class NativeMethods
     [DllImport("user32.dll", CharSet = CharSet.Unicode)]
     public static extern bool EnumDisplaySettings(string lpszDeviceName, int iModeNum, ref DEVMODE lpDevMode);
 
+    // --- DDC/CI (物理モニタ入力ソース取得) -----------------------------------
+    public delegate bool MonitorEnumProc(IntPtr hMonitor, IntPtr hdc, IntPtr lprcMonitor, IntPtr dwData);
+
+    [DllImport("user32.dll")]
+    public static extern bool EnumDisplayMonitors(IntPtr hdc, IntPtr lprcClip, MonitorEnumProc lpfnEnum, IntPtr dwData);
+
+    [DllImport("dxva2.dll", SetLastError = true)]
+    public static extern bool GetNumberOfPhysicalMonitorsFromHMONITOR(IntPtr hMonitor, out uint pdwNumberOfPhysicalMonitors);
+
+    [DllImport("dxva2.dll", SetLastError = true)]
+    public static extern bool GetPhysicalMonitorsFromHMONITOR(IntPtr hMonitor, uint dwPhysicalMonitorArraySize, [Out] PHYSICAL_MONITOR[] pPhysicalMonitorArray);
+
+    [DllImport("dxva2.dll", SetLastError = true)]
+    public static extern bool DestroyPhysicalMonitors(uint dwPhysicalMonitorArraySize, [In] PHYSICAL_MONITOR[] pPhysicalMonitorArray);
+
+    [DllImport("dxva2.dll", SetLastError = true)]
+    public static extern bool GetVCPFeatureAndVCPFeatureReply(IntPtr hMonitor, byte bVCPCode, out uint pvct, out uint pdwCurrentValue, out uint pdwMaximumValue);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct PHYSICAL_MONITOR
+    {
+        public IntPtr hPhysicalMonitor;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public string szPhysicalMonitorDescription;
+    }
+
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     public struct WNDCLASSEX
     {

--- a/src/LGTVSwitcher.Daemon.Windows/appsettings.json
+++ b/src/LGTVSwitcher.Daemon.Windows/appsettings.json
@@ -7,7 +7,7 @@
     "AllowedCurrentInputIds": [],
     "SyncIntervalSeconds": 15,
     "PreferredMonitorName": "U2725QE",
-    "PreferredMonitorThisPcInputSources": [ 15 ]
+    "PreferredMonitorThisPcInputSources": [ "DisplayPort" ]
   },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],

--- a/src/LGTVSwitcher.Daemon.Windows/appsettings.json
+++ b/src/LGTVSwitcher.Daemon.Windows/appsettings.json
@@ -6,7 +6,8 @@
     "FallbackInputId": "",
     "AllowedCurrentInputIds": [],
     "SyncIntervalSeconds": 15,
-    "PreferredMonitorName": "U2725QE"
+    "PreferredMonitorName": "U2725QE",
+    "PreferredMonitorThisPcInputSources": [ 15 ]
   },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],

--- a/src/LgtvSwitcher.MacOS/MacDaemonHost.cs
+++ b/src/LgtvSwitcher.MacOS/MacDaemonHost.cs
@@ -55,6 +55,9 @@ internal static class MacDaemonHost
 
         services.AddSingleton<IDisplaySnapshotProvider, MacDisplayWatcher>();
 
+        // macOS は DDC 入力ソース判定を未実装のため、常に Unknown を返し列挙ベース判定へフォールバックする。
+        services.AddSingleton<IPreferredInputSourceProbe, NullPreferredInputSourceProbe>();
+
         services.AddHostedService<DisplaySyncWorker>();
     }
 }

--- a/tests/LGTVSwitcher.Core.Tests/DisplaySyncWorkerTests.cs
+++ b/tests/LGTVSwitcher.Core.Tests/DisplaySyncWorkerTests.cs
@@ -29,7 +29,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -57,7 +57,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -80,7 +80,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -105,7 +105,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -130,7 +130,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -156,7 +156,7 @@ public class DisplaySyncWorkerTests
             AllowedCurrentInputIds = new[] { "HDMI_2" },
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -182,7 +182,7 @@ public class DisplaySyncWorkerTests
             AllowedCurrentInputIds = new[] { "HDMI_2" },
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -206,7 +206,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -235,7 +235,7 @@ public class DisplaySyncWorkerTests
             SyncIntervalSeconds = 1,
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -258,7 +258,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -283,7 +283,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -314,7 +314,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -342,7 +342,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -370,7 +370,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -399,7 +399,7 @@ public class DisplaySyncWorkerTests
             AllowedCurrentInputIds = new[] { "HDMI_2" },
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -427,7 +427,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -456,7 +456,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -479,7 +479,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -513,7 +513,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -548,7 +548,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -576,7 +576,7 @@ public class DisplaySyncWorkerTests
             SyncIntervalSeconds = 1,
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -611,7 +611,7 @@ public class DisplaySyncWorkerTests
             PreferredMonitorName = "TEST",
         });
 
-        using var worker = new DisplaySyncWorker(provider, controller, options, NullLogger<DisplaySyncWorker>.Instance);
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
 
         await worker.StartAsync(CancellationToken.None);
         await WaitForStart(provider);
@@ -621,6 +621,67 @@ public class DisplaySyncWorkerTests
         Assert.True(switched, "Expected switch to proceed despite non-network query error with empty allowed list.");
 
         await worker.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task OtherSourceInput_ShouldNotStealTvEvenIfMonitorEnumeratedOnline()
+    {
+        // 列挙上は online（DELLがDPリンクを維持）だが、DDCでは Mac(USB-C) を映していると判明したケース。
+        // TV を Mac の入力から奪ってはならない。
+        var provider = new FakeSnapshotProvider();
+        var controller = new FakeLgTvController { CurrentInput = "HDMI_1" }; // TV は Mac 入力を表示中
+        var probe = new FakeInputSourceProbe { Result = PreferredInputSource.OtherSource };
+        var options = Options.Create(new LgTvSwitcherOptions
+        {
+            TargetInputId = "HDMI_4",
+            FallbackInputId = "", // オフライン時は何もしない
+            PreferredMonitorName = "TEST",
+        });
+
+        using var worker = new DisplaySyncWorker(provider, controller, probe, options, NullLogger<DisplaySyncWorker>.Instance);
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitForStart(provider);
+        await Task.Delay(100);
+        provider.Publish(CreateSnapshot(online: true));
+
+        var switched = await WaitForSwitchAsync(controller, call => call == "HDMI_4", timeoutMs: 1200);
+        Assert.False(switched, "DDC が OtherSource のとき HDMI_4 へ切り替えてはならない。");
+
+        await worker.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ThisPcInput_ShouldSwitchEvenIfMonitorEnumeratedOffline()
+    {
+        // 列挙が一瞬 DELL を取りこぼして online=false でも、DDC が「このPCを映している」と言えば切り替える。
+        var provider = new FakeSnapshotProvider();
+        var controller = new FakeLgTvController();
+        var probe = new FakeInputSourceProbe { Result = PreferredInputSource.ThisPc };
+        var options = Options.Create(new LgTvSwitcherOptions
+        {
+            TargetInputId = "HDMI_4",
+            FallbackInputId = "",
+            PreferredMonitorName = "TEST",
+        });
+
+        using var worker = new DisplaySyncWorker(provider, controller, probe, options, NullLogger<DisplaySyncWorker>.Instance);
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitForStart(provider);
+        await Task.Delay(100);
+        provider.Publish(CreateSnapshot(online: false));
+
+        var switched = await WaitForSwitchAsync(controller, call => call == "HDMI_4");
+        Assert.True(switched, "DDC が ThisPc のとき HDMI_4 へ切り替えるべき。");
+
+        await worker.StopAsync(CancellationToken.None);
+    }
+
+    private sealed class FakeInputSourceProbe : IPreferredInputSourceProbe
+    {
+        public PreferredInputSource Result { get; set; } = PreferredInputSource.Unknown;
+        public PreferredInputSource Probe() => Result;
     }
 
     private static DisplaySnapshot CreateSnapshot(bool online, int ageSeconds = 0, string? edidKey = "EDID-TEST", MonitorConnectionKind connection = MonitorConnectionKind.Hdmi)

--- a/tests/LGTVSwitcher.Core.Tests/MonitorInputSourceCatalogTests.cs
+++ b/tests/LGTVSwitcher.Core.Tests/MonitorInputSourceCatalogTests.cs
@@ -1,0 +1,48 @@
+using LGTVSwitcher.Core.Display;
+
+using Xunit;
+
+namespace LGTVSwitcher.Core.Tests;
+
+public class MonitorInputSourceCatalogTests
+{
+    [Theory]
+    [InlineData("DisplayPort", 0x0F)]
+    [InlineData("DP", 0x0F)]
+    [InlineData("displayport", 0x0F)] // 大文字小文字は無視
+    [InlineData("DisplayPort2", 0x10)]
+    [InlineData("HDMI", 0x11)]
+    [InlineData("HDMI2", 0x12)]
+    [InlineData("USB-C", 0x19)]
+    [InlineData("Thunderbolt", 0x19)]
+    [InlineData("  HDMI  ", 0x11)] // 前後空白は無視
+    public void TryResolve_KnownName_ReturnsCode(string name, int expected)
+    {
+        var ok = MonitorInputSourceCatalog.TryResolve(name, out var code);
+        Assert.True(ok);
+        Assert.Equal(expected, code);
+    }
+
+    [Theory]
+    [InlineData("0x1B", 0x1B)]
+    [InlineData("0X1b", 0x1B)]
+    [InlineData("27", 27)]
+    public void TryResolve_RawValue_ReturnsCode(string value, int expected)
+    {
+        var ok = MonitorInputSourceCatalog.TryResolve(value, out var code);
+        Assert.True(ok);
+        Assert.Equal(expected, code);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("NotAnInput")]
+    public void TryResolve_InvalidValue_ReturnsFalse(string? value)
+    {
+        var ok = MonitorInputSourceCatalog.TryResolve(value, out var code);
+        Assert.False(ok);
+        Assert.Equal(0, code);
+    }
+}


### PR DESCRIPTION
## Why（なぜ）
「DELL を Mac 表示にしているのに LGTV が勝手に HDMI_4 へ切り替わる」不具合の修正。

DELL U2725QE のような USB-C/KVM ハブ搭載モニタは、**表示ソースを Mac(USB-C) へ切り替えても Windows への DisplayPort リンクを生かしたまま**にする。そのため Windows の列挙(GDI/WMI)ではモニタが常に「接続中(Active=True)」に見え、`PreferredMonitorOnline=true` と誤判定 → 15秒周期の同期が TV を Mac から HDMI_4 へ奪い返し続けていた。

実機ログ(今日 07:28〜07:32)で、TV 正常稼働中に DELL の一瞬のフラップを機に `Switching LG TV input to HDMI_4` が実送出されていたことを確認済み。

## 設計判断（なぜこの実装か）
- Windows 側の列挙情報には Win/Mac を区別できるフィールドが**存在しない**（過去6日分のログ発掘でも、DELL のスナップショットは Bounds/Primary が LG TV の在/不在に連動するだけで、Mac 表示とは無関係だった）。
- 唯一確実な信号は **DDC/CI VCP 0x60(Input Source)**。DisplayPort リンクが生きていてもモニタは現在選択中の入力を報告する。実機で **Windows 表示=0x0F(DisplayPort) / Mac 表示=0x19(USB-C)** を両状態とも確認（Capabilities は `60( 19 0F 11)`）。
- Mac への表示切替は**ディスプレイ変化イベントを発火しない**ため、スナップショットに焼き込むと定期同期がすり抜ける。よって**同期判定の度に都度 DDC を読む**設計とした。
- DDC は稀に読み取り失敗するため、**リトライ＋直近確定値の保持**で一過性の失敗時に TV を奪わないようにした（失敗→列挙フォールバック→奪取、の再発を防止）。

## 変更内容（何を加えたか）
- **Core**: `IPreferredInputSourceProbe` / `PreferredInputSource`(ThisPc/OtherSource/Unknown) / `NullPreferredInputSourceProbe` を追加。
- **Windows**: `DdcInputSourceProbe`（VCP 0x60 読取＋リトライ＋ヒステリシス）、`NativeMethods` に DDC 系 P/Invoke(dxva2)追加。
- **DisplaySyncWorker**: 判定時にプローブを実行し、`ThisPc→online` / `OtherSource→offline(TV に触れない)` / `Unknown→従来の列挙ベースへフォールバック`。
- **設定**: `PreferredMonitorThisPcInputSources`(既定 `[15]`=DisplayPort) を追加。空で DDC 判定を無効化=従来動作。
- **macOS**: `NullPreferredInputSourceProbe` を登録（DDC 未対応のため従来動作）。
- **診断**: `probe-input` コマンド追加（優先モニタの現在入力を表示）。
- **docs**: README / AGENTS.md(=CLAUDE.md) に DDC 判定の説明を追記。

## テストプラン
- Core UT 追加2本：
  - OtherSource のとき列挙上 online でも HDMI_4 へ切り替えない（奪取しない）
  - ThisPc のとき列挙が offline でも HDMI_4 へ切り替える
- 全テスト緑（Core 51 / DisplayDetection.Windows 15 / LgWebOsClient 25）。
- 実機 E2E：`probe-input` が Windows 表示中 `ThisPc`(4/4) / Mac 表示中 `OtherSource`(6/6)。Debug/Release ビルド 0エラー。

## 既知の制約
- DDC を持たない/無効化した環境は従来の列挙ベース判定にフォールバックする（Windows 実機では DDC 前提）。
- SSDP 探索が TV オフライン時に無駄なマルチインターフェース試行でログを肥大化させる件は本 PR の範囲外（別途対応）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)