### PR TITLE
fix: ログ肥大化を解消（定常ノイズのDebug降格・仮想NIC除外・オフライン遷移ログ化）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@
 - **WindowsDisplaySnapshotProvider のメッセージループ**:
   - 非 UI の STA メッセージループを持つ Hidden Window を使用する。Windows の仕様上必須であり、非同期化・スレッド切替で破壊しないこと。
   - `DisplayDetection/` 内で `Task.Run` や `ConfigureAwait` の軽率な使用は禁止。
-- **ログ**: 初期スナップショットは Information、それ以外は Debug。WebSocket 例外は Warning 1 行、詳細は Debug。
+- **ログ**: 状態遷移・実際の入力切替のみ Information。定常反復（`Already connected`/`already set; no switch`/SSDP の discover start・summary・final result・`No input mapping…skipping`）は Debug に留めてログ肥大を防ぐ。WebSocket 例外は Warning 1 行、詳細は Debug。**TV 到達不可（ネットワーク断・未検出/オフライン=`LgTvRegistrationException`）は正常運用でも起きるため、遷移時に一度だけ Warning、以降は Debug**（`_tvUnavailableLogged` で管理。復帰時に Information）。SSDP 探索は WSL/Tailscale 等の仮想 NIC を `SsdpInterfaceFilter` で除外する。
 
 ## テスト方針
 - Core: DisplaySyncWorker のオンライン/オフライン、stale 無視、冗長スイッチ抑止、例外スキップを UT で担保。

--- a/src/LGTVSwitcher.Core/LgWebOs/Discovery/SsdpInterfaceFilter.cs
+++ b/src/LGTVSwitcher.Core/LgWebOs/Discovery/SsdpInterfaceFilter.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace LGTVSwitcher.Core.LgWebOs;
+
+/// <summary>
+/// SSDP 探索の対象から除外すべき仮想/トンネル系ネットワークインターフェースを判定する。
+/// </summary>
+/// <remarks>
+/// WSL の vEthernet や Tailscale/VPN などの仮想アダプタは LG TV が居る物理 LAN とは別セグメントで、
+/// マルチキャスト探索しても応答が返らない（recv=0）。毎サイクル無駄打ちして CPU とログを消費するため除外する。
+/// 名前・説明の部分一致（大文字小文字無視）で判定する保守的なヒューリスティック。
+/// </remarks>
+public static class SsdpInterfaceFilter
+{
+    private static readonly string[] VirtualNameHints =
+    [
+        "wsl",
+        "vethernet",
+        "hyper-v",
+        "virtual",
+        "vmware",
+        "virtualbox",
+        "tailscale",
+        "zerotier",
+        "docker",
+        "loopback",
+        "vpn",
+        "tap-windows",
+        "bluetooth",
+    ];
+
+    /// <summary>
+    /// NIC の名前または説明が仮想/トンネル系を示す場合 true。
+    /// </summary>
+    public static bool IsVirtual(string? name, string? description)
+        => ContainsHint(name) || ContainsHint(description);
+
+    private static bool ContainsHint(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        foreach (var hint in VirtualNameHints)
+        {
+            if (value.Contains(hint, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/LGTVSwitcher.Core/LgWebOs/Discovery/SsdpLgTvDiscoveryService.cs
+++ b/src/LGTVSwitcher.Core/LgWebOs/Discovery/SsdpLgTvDiscoveryService.cs
@@ -65,7 +65,7 @@ public sealed class SsdpLgTvDiscoveryService : ILgTvDiscoveryService
         }
 
         var aggregated = AggregateByAddress(allResponses);
-        _logger.LogInformation("SSDP final result: {Count} TV candidates after aggregation.", aggregated.Count);
+        _logger.LogDebug("SSDP final result: {Count} TV candidates after aggregation.", aggregated.Count);
         return aggregated;
     }
 
@@ -88,7 +88,7 @@ public sealed class SsdpLgTvDiscoveryService : ILgTvDiscoveryService
             udp.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastInterface, nic.Address.GetAddressBytes());
 
             var localEndpoint = (IPEndPoint)udp.Client.LocalEndPoint!;
-            _logger.LogInformation("SSDP discover start on {LocalIp}:{LocalPort} ({NicName})", localEndpoint.Address, localEndpoint.Port, nic.Name);
+            _logger.LogDebug("SSDP discover start on {LocalIp}:{LocalPort} ({NicName})", localEndpoint.Address, localEndpoint.Port, nic.Name);
 
             foreach (var st in SearchTargets)
             {
@@ -152,7 +152,7 @@ public sealed class SsdpLgTvDiscoveryService : ILgTvDiscoveryService
                 }
             }
 
-            _logger.LogInformation("SSDP summary on {LocalIp}: sent={Sent} recv={Recv} accepted={Accepted} rejected={Rejected}",
+            _logger.LogDebug("SSDP summary on {LocalIp}: sent={Sent} recv={Recv} accepted={Accepted} rejected={Rejected}",
                 nic.Address, SearchTargets.Length, recvCount, accepted, rejected);
         }
         catch (Exception ex) when (ex is SocketException or ObjectDisposedException)
@@ -209,7 +209,7 @@ public sealed class SsdpLgTvDiscoveryService : ILgTvDiscoveryService
         return newlineIndex >= 0 ? text[..newlineIndex] : text;
     }
 
-    private static List<LocalInterface> GetCandidateInterfaces()
+    private List<LocalInterface> GetCandidateInterfaces()
     {
         var interfaces = new List<LocalInterface>();
 
@@ -220,6 +220,13 @@ public sealed class SsdpLgTvDiscoveryService : ILgTvDiscoveryService
                 nic.NetworkInterfaceType == NetworkInterfaceType.Tunnel ||
                 !nic.SupportsMulticast)
             {
+                continue;
+            }
+
+            // WSL/Tailscale/VPN 等の仮想 NIC は物理 LAN と別セグメントで応答が返らないため除外する。
+            if (SsdpInterfaceFilter.IsVirtual(nic.Name, nic.Description))
+            {
+                _logger.LogDebug("SSDP skipping virtual interface: {NicName} ({NicDescription})", nic.Name, nic.Description);
                 continue;
             }
 

--- a/src/LGTVSwitcher.Core/LgWebOs/Session/LgTvSession.cs
+++ b/src/LGTVSwitcher.Core/LgWebOs/Session/LgTvSession.cs
@@ -59,7 +59,7 @@ public sealed class LgTvSession : ILgTvSession
     {
         if (_transport.State == WebSocketState.Open && _isRegistered)
         {
-            _logger.LogInformation("Already connected and registered with LG TV");
+            _logger.LogDebug("Already connected and registered with LG TV");
             return;
         }
 
@@ -249,7 +249,8 @@ public sealed class LgTvSession : ILgTvSession
                 return new[] { ToEndpoint(match) };
             }
 
-            _logger.LogWarning("PreferredTvUsn {Usn} was not found via SSDP discovery. Skipping fallback to other TVs.", _options.PreferredTvUsn);
+            // TV がスリープ/オフの間は毎サイクル発生する正常な状態のため Debug に留める。
+            _logger.LogDebug("PreferredTvUsn {Usn} was not found via SSDP discovery. Skipping fallback to other TVs.", _options.PreferredTvUsn);
             return Array.Empty<LgTvEndpoint>();
         }
 

--- a/src/LGTVSwitcher.Core/Workers/DisplaySyncWorker.cs
+++ b/src/LGTVSwitcher.Core/Workers/DisplaySyncWorker.cs
@@ -6,6 +6,7 @@ using System.Threading.Channels;
 
 using LGTVSwitcher.Core.Display;
 using LGTVSwitcher.Core.LgTv;
+using LGTVSwitcher.Core.LgWebOs;
 
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -25,6 +26,9 @@ public sealed class DisplaySyncWorker : BackgroundService
     private readonly string[] _allowedCurrentInputIds;
     private readonly TimeSpan? _syncInterval;
     private volatile DisplaySnapshot? _latestSnapshot;
+
+    // TV 到達不可を Warning で通知したか。スリープ/オフ中に毎サイクル警告を出さないための遷移フラグ。
+    private bool _tvUnavailableLogged;
 
     public DisplaySyncWorker(
         IDisplaySnapshotProvider snapshotProvider,
@@ -127,14 +131,39 @@ public sealed class DisplaySyncWorker : BackgroundService
             await SyncLgTvAsync(snapshot, ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
-        catch (Exception ex) when (IsNetworkException(ex))
+        catch (Exception ex) when (IsTvUnavailable(ex))
         {
-            _logger.LogWarning("LG TV transport error; skipping snapshot: {Message}", ex.Message);
-            _logger.LogDebug(ex, "LG TV transport exception details.");
+            LogTvUnavailable(ex);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "LG TV sync failed.");
+        }
+    }
+
+    // TV 到達不可（ネットワーク断・未検出/オフライン）は正常運用でも起きる。
+    // 遷移時に一度だけ Warning を出し、以降は Debug に留めてログ肥大を防ぐ。
+    private void LogTvUnavailable(Exception ex)
+    {
+        if (!_tvUnavailableLogged)
+        {
+            _logger.LogWarning("LG TV is unreachable (asleep/offline?); will keep retrying quietly: {Message}", ex.Message);
+            _tvUnavailableLogged = true;
+        }
+        else
+        {
+            _logger.LogDebug("LG TV still unreachable: {Message}", ex.Message);
+        }
+
+        _logger.LogDebug(ex, "LG TV unavailable exception details.");
+    }
+
+    private void MarkTvReachable()
+    {
+        if (_tvUnavailableLogged)
+        {
+            _logger.LogInformation("LG TV is reachable again.");
+            _tvUnavailableLogged = false;
         }
     }
 
@@ -160,7 +189,7 @@ public sealed class DisplaySyncWorker : BackgroundService
         var targetInput = effectiveOnline ? _options.TargetInputId : _options.FallbackInputId;
         if (string.IsNullOrWhiteSpace(targetInput))
         {
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "No input mapping configured for preferred monitor state {State} (input source={Source}); skipping.",
                 effectiveOnline,
                 showing);
@@ -171,11 +200,12 @@ public sealed class DisplaySyncWorker : BackgroundService
         try
         {
             currentInput = await _lgTvController.GetCurrentInputAsync(cancellationToken).ConfigureAwait(false);
+            MarkTvReachable();
         }
-        catch (Exception ex) when (!cancellationToken.IsCancellationRequested && IsNetworkException(ex))
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested && IsTvUnavailable(ex))
         {
-            _logger.LogWarning("Failed to query LG TV input; skipping snapshot: {Message}", ex.Message);
-            _logger.LogDebug(ex, "LG TV input query exception details.");
+            // TV がオフライン/未検出のときは切替も失敗するため、静かにスキップする。
+            LogTvUnavailable(ex);
             return;
         }
         catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
@@ -200,7 +230,7 @@ public sealed class DisplaySyncWorker : BackgroundService
         if (!string.IsNullOrWhiteSpace(currentInput) &&
             string.Equals(currentInput, targetInput, StringComparison.OrdinalIgnoreCase))
         {
-            _logger.LogInformation("LG TV already set to {Input}; no switch required.", targetInput);
+            _logger.LogDebug("LG TV already set to {Input}; no switch required.", targetInput);
             return;
         }
 
@@ -228,6 +258,30 @@ public sealed class DisplaySyncWorker : BackgroundService
     private static bool IsEligibleSnapshot(DisplaySnapshot snapshot)
         => !string.IsNullOrWhiteSpace(snapshot.PreferredMonitorEdidKey) &&
            (snapshot.PreferredMonitor is null || snapshot.PreferredMonitor.ConnectionKind != MonitorConnectionKind.Unknown);
+
+    // TV 到達不可とみなす例外（ネットワーク断、または未検出/登録失敗＝オフライン）。
+    private static bool IsTvUnavailable(Exception ex)
+    {
+        if (IsNetworkException(ex))
+        {
+            return true;
+        }
+
+        if (ex is AggregateException aggregate)
+        {
+            return aggregate.InnerExceptions.Any(IsTvUnavailable);
+        }
+
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            if (current is LgTvRegistrationException)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     private static bool IsNetworkException(Exception ex)
     {

--- a/tests/LGTVSwitcher.Core.Tests/DisplaySyncWorkerTests.cs
+++ b/tests/LGTVSwitcher.Core.Tests/DisplaySyncWorkerTests.cs
@@ -678,6 +678,37 @@ public class DisplaySyncWorkerTests
         await worker.StopAsync(CancellationToken.None);
     }
 
+    [Fact]
+    public async Task TvUnavailableOnQuery_ShouldSkipWithoutSwitching()
+    {
+        // TV がオフライン（未検出）で GetCurrentInput が登録例外を投げるとき、切替を試みず静かにスキップする。
+        var provider = new FakeSnapshotProvider();
+        var controller = new FakeLgTvController
+        {
+            QueryException = new LgTvRegistrationException("No LG TV discovered via SSDP or configuration."),
+        };
+        var probe = new FakeInputSourceProbe { Result = PreferredInputSource.ThisPc };
+        var options = Options.Create(new LgTvSwitcherOptions
+        {
+            TargetInputId = "HDMI_4",
+            FallbackInputId = "",
+            PreferredMonitorName = "TEST",
+        });
+
+        using var worker = new DisplaySyncWorker(provider, controller, probe, options, NullLogger<DisplaySyncWorker>.Instance);
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitForStart(provider);
+        await Task.Delay(100);
+        provider.Publish(CreateSnapshot(online: true));
+
+        await Task.Delay(1200);
+
+        Assert.Empty(controller.SwitchCalls);
+
+        await worker.StopAsync(CancellationToken.None);
+    }
+
     private sealed class FakeInputSourceProbe : IPreferredInputSourceProbe
     {
         public PreferredInputSource Result { get; set; } = PreferredInputSource.Unknown;

--- a/tests/LGTVSwitcher.Core.Tests/SsdpInterfaceFilterTests.cs
+++ b/tests/LGTVSwitcher.Core.Tests/SsdpInterfaceFilterTests.cs
@@ -1,0 +1,35 @@
+using LGTVSwitcher.Core.LgWebOs;
+
+using Xunit;
+
+namespace LGTVSwitcher.Core.Tests;
+
+public class SsdpInterfaceFilterTests
+{
+    [Theory]
+    [InlineData("vEthernet (WSL (Hyper-V firewall))", "Hyper-V Virtual Ethernet Adapter")]
+    [InlineData("Tailscale", "Tailscale Tunnel")]
+    [InlineData("VMware Network Adapter VMnet1", "VMware Virtual Ethernet Adapter")]
+    [InlineData("Loopback Pseudo-Interface 1", "Software Loopback Interface")]
+    [InlineData("イーサネット 2", "TAP-Windows Adapter V9")]
+    public void IsVirtual_VirtualAdapters_ReturnsTrue(string name, string description)
+    {
+        Assert.True(SsdpInterfaceFilter.IsVirtual(name, description));
+    }
+
+    [Theory]
+    [InlineData("イーサネット", "Realtek PCIe GbE Family Controller")]
+    [InlineData("Wi-Fi", "Intel(R) Wi-Fi 6E AX211 160MHz")]
+    [InlineData("Ethernet", "Aquantia AQtion 10Gbit Network Adapter")]
+    public void IsVirtual_PhysicalAdapters_ReturnsFalse(string name, string description)
+    {
+        Assert.False(SsdpInterfaceFilter.IsVirtual(name, description));
+    }
+
+    [Fact]
+    public void IsVirtual_NullOrEmpty_ReturnsFalse()
+    {
+        Assert.False(SsdpInterfaceFilter.IsVirtual(null, null));
+        Assert.False(SsdpInterfaceFilter.IsVirtual("", "   "));
+    }
+}


### PR DESCRIPTION
## Why（なぜ）
TV オフライン時に1日 6〜11MB のログが出ていた。原因は **15秒周期で毎回 Information / フルスタック Warning を吐く定常ノイズ**と、**WSL/Tailscale 等の仮想 NIC への無駄なマルチキャスト探索**。

内訳（調査時の実測）: `SSDP discover start`/`summary` が各約3000行/日、`PreferredTvUsn not found` WARN が約3000行/日、加えて TV 到達不可時に `LgTvRegistrationException` のフルスタック Warning が毎サイクル。

## 設計判断（なぜこの実装か）
- **状態遷移・実際の入力切替だけ Information**、定常反復は Debug、という方針に整理（トラブル時は Debug で追える）。
- TV がスリープ/オフなのは**正常運用でも起きる状態**。毎サイクル Warning は誤り。**遷移時に一度だけ Warning、以降 Debug、復帰時に Information** とした（`_tvUnavailableLogged`）。
- オフライン時は `GetCurrentInput` が失敗した時点で**静かにスキップ**し、無駄な `switchInput` 試行と2つ目の例外（フルスタック）を出さない。
- 仮想 NIC は物理 LAN と別セグメントで応答が返らない（recv=0）。保守的な名前ヒューリスティック（`SsdpInterfaceFilter`）で除外し、CPU とログの無駄打ちを削減。

## 変更内容（何を加えたか）
- 定常反復ログを Information→Debug に降格: SSDP `discover start`/`summary`/`final result`、`Already connected and registered`、`already set; no switch required`、`No input mapping…skipping`。
- `IsTvUnavailable`（ネットワーク断＋`LgTvRegistrationException`）で TV 到達不可を一括判定し、遷移ベースのログ（`LogTvUnavailable`/`MarkTvReachable`）に集約。オフライン時は切替を試みない。
- `SsdpInterfaceFilter` を追加し、WSL/vEthernet/Hyper-V/VMware/Tailscale/VPN 等の仮想 NIC を探索対象から除外。
- AGENTS.md(=CLAUDE.md) のログ方針を更新。

## テストプラン
- UT 追加: `SsdpInterfaceFilter`（仮想/物理 NIC 名の判定、null/空）、TV 到達不可時に切替を試みないこと。
- 全テスト緑（Core 77 / DisplayDetection.Windows 15 / LgWebOsClient 25）。
- 実機確認: 新ビルドを約30秒稼働させ、初期スナップショット/接続/client-key 以外の **Information 出力がゼロ**（SSDP・`already set`・`already connected` が Information から消えたことを確認）。

## 既知の制約
- 仮想 NIC 判定は名前の部分一致ヒューリスティック。物理 NIC 名に該当語が入る稀なケースでは除外し過ぎる可能性があるが、生の LAN(例: Realtek/Intel/Aquantia)には該当しない。必要なら将来的に設定で上書き可能にする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)