### PR TITLE
feat: Mac 表示時に LGTV を FallbackInputId(HDMI_2) へ追従

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ PCとMacで1台の高性能モニター（例：Dell U2725QE）を共有して�
 
 Dell U2725QE のような USB-C/KVM ハブ搭載モニタは、**表示ソースを別PC(Mac の USB-C 等)へ切り替えても、Windows への DisplayPort リンクを生かしたまま**にします。そのため Windows の列挙(GDI/WMI)ではモニタが常に「接続中」に見え、「今このPCを映しているか」を判別できません（このツールが TV を勝手に奪ってしまう原因でした）。
 
-そこで **DDC/CI（VCP 0x60 = Input Source）でモニタ本体に「今どの入力を映しているか」を直接問い合わせ**、優先モニタが `PreferredMonitorThisPcInputSources` の入力（既定は DisplayPort）を映しているときだけ TV を `TargetInputId` に切り替えます。別ソース(Mac)を映している間は TV に一切触れません。DDC は稀に読み取りに失敗するため、短時間リトライと直近確定値の保持で判定を安定させています。
+そこで **DDC/CI（VCP 0x60 = Input Source）でモニタ本体に「今どの入力を映しているか」を直接問い合わせ**、優先モニタが `PreferredMonitorThisPcInputSources` の入力（既定は DisplayPort）を映しているときだけ TV を `TargetInputId` に切り替えます。別ソース(Mac)を映しているときは `FallbackInputId` に切り替えます（`FallbackInputId` が空なら TV に一切触れません）。つまり **`FallbackInputId` に Mac 側の入力（例: `HDMI_2`）を設定すると、Mac に切り替えた瞬間に TV もそちらへ追従**します。DDC は稀に読み取りに失敗するため、短時間リトライと直近確定値の保持で判定を安定させています。
+
+Mac 側の入力 ID が分からない場合は、TV を Mac 表示にした状態で次のコマンドを実行すると現在の入力 ID を確認できます:
+
+```powershell
+dotnet run --project src/LGTVSwitcher.Daemon.Windows -- tv-input
+```
 
 対応値の確認は次のコマンドで行えます（優先モニタの現在入力ソースを表示）:
 

--- a/src/LGTVSwitcher.Daemon.Windows/DaemonCommands.cs
+++ b/src/LGTVSwitcher.Daemon.Windows/DaemonCommands.cs
@@ -20,6 +20,17 @@ public sealed class DaemonCommands
         await host.RunAsync(ct).ConfigureAwait(false);
     }
 
+    /// <summary>LG TV の現在の入力IDを表示（FallbackInputId 設定用の検出に使う）</summary>
+    [Command("tv-input")]
+    public async Task TvInput(CancellationToken ct = default)
+    {
+        using var host = DaemonHost.Build(Array.Empty<string>());
+        using var scope = host.Services.CreateScope();
+        var controller = scope.ServiceProvider.GetRequiredService<ILgTvController>();
+        var input = await controller.GetCurrentInputAsync(ct).ConfigureAwait(false);
+        Console.WriteLine($"TV current input = {input ?? "(unknown)"}");
+    }
+
     /// <summary>優先モニタの現在の入力ソースを DDC/CI で読む（検証用POC）</summary>
     [Command("probe-input")]
     public Task ProbeInput()

--- a/src/LGTVSwitcher.Daemon.Windows/appsettings.json
+++ b/src/LGTVSwitcher.Daemon.Windows/appsettings.json
@@ -3,7 +3,7 @@
     "TvHost": "lgwebostv.local",
     "TvPort": 3001,
     "TargetInputId": "HDMI_4",
-    "FallbackInputId": "",
+    "FallbackInputId": "HDMI_2",
     "AllowedCurrentInputIds": [],
     "SyncIntervalSeconds": 15,
     "PreferredMonitorName": "U2725QE",

--- a/tests/LGTVSwitcher.Core.Tests/DisplaySyncWorkerTests.cs
+++ b/tests/LGTVSwitcher.Core.Tests/DisplaySyncWorkerTests.cs
@@ -652,6 +652,33 @@ public class DisplaySyncWorkerTests
     }
 
     [Fact]
+    public async Task OtherSourceInput_WithFallbackConfigured_ShouldFollowToFallback()
+    {
+        // DDC が OtherSource(Mac) のとき、FallbackInputId が設定されていれば TV をそちら（Mac の入力）へ追従させる。
+        var provider = new FakeSnapshotProvider();
+        var controller = new FakeLgTvController { CurrentInput = "HDMI_4" };
+        var probe = new FakeInputSourceProbe { Result = PreferredInputSource.OtherSource };
+        var options = Options.Create(new LgTvSwitcherOptions
+        {
+            TargetInputId = "HDMI_4",
+            FallbackInputId = "HDMI_2",
+            PreferredMonitorName = "TEST",
+        });
+
+        using var worker = new DisplaySyncWorker(provider, controller, probe, options, NullLogger<DisplaySyncWorker>.Instance);
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitForStart(provider);
+        await Task.Delay(100);
+        provider.Publish(CreateSnapshot(online: true));
+
+        var switched = await WaitForSwitchAsync(controller, call => call == "HDMI_2");
+        Assert.True(switched, "DDC が OtherSource かつ Fallback 設定時は HDMI_2 へ追従すべき。");
+
+        await worker.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
     public async Task ThisPcInput_ShouldSwitchEvenIfMonitorEnumeratedOffline()
     {
         // 列挙が一瞬 DELL を取りこぼして online=false でも、DDC が「このPCを映している」と言えば切り替える。


### PR DESCRIPTION
## Why（なぜ）
DELL を Mac へ切り替えたとき、LGTV も Mac の入力（HDMI_2）へ自動追従させたい。

## 設計判断
既存の `FallbackInputId`（優先モニタがオフライン=DDC で `OtherSource` のときに切り替える入力）でそのまま実現できる。DDC 判定により「Mac を映している」＝`OtherSource` を正しく検出できるため、`FallbackInputId` に Mac 側入力を設定するだけでよい。コードの分岐追加は不要。

## 変更内容
- `appsettings.json` の `FallbackInputId` を `"HDMI_2"` に設定（Mac 追従を有効化）。
- 診断コマンド `tv-input` を追加（TV の現在入力 ID を表示。Fallback に設定すべき値の検出用）。
- 回帰テスト追加: DDC=`OtherSource` かつ `FallbackInputId` 設定時に、その入力へ追従切替すること。
- README に追従挙動と `tv-input` の使い方を追記。

## 挙動
- DELL=DisplayPort(Windows) → TV は `HDMI_4`
- DELL=USB-C(Mac) → TV は `HDMI_2`（← 今回追加）

## テストプラン
- 全テスト緑（Core 78 / DisplayDetection.Windows 15 / LgWebOsClient 25）。
- `tv-input` で TV 現在入力の取得が動作することを実機確認（Windows 表示中に `HDMI_4` を返却）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)