### PR TITLE
fix: TV 無応答時のハングを打ち切り、同期ループの永久停止を防ぐ

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
   - Preferred monitor 以外のモニタ変化でも Sync が走ることを期待。この動作を破壊しないこと。
   - ネットワーク例外（WebSocket/HttpRequest/Socket）はそのスナップショットを捨て、ループは継続。
 - **LGTV 同期**: オンライン/オフライン双方で Target/Fallback を自動切替。既に目標入力なら冪等スキップ。
+- **タイムアウト（ハング防止）**: TV がスタンバイへ入ると TCP は張れても TLS ハンドシェイクや送受信の応答が返らない。`TvConnectTimeoutSeconds`（既定 10 秒 / `LgTvSession.ConnectTransportAsync`）で接続を、`SyncTimeoutSeconds`（既定 30 秒 / `DisplaySyncWorker.TrySyncAsync`）で同期 1 サイクル全体を打ち切る。**どちらも外してはならない**——上限が無いと接続ロックを握ったまま同期ループが永久停止し、プロセスは生きていてディスプレイ検知も動くのに切替だけが死ぬ。打ち切りは TV 到達不可と同じ扱いにして次サイクルで張り直す。ペアリング待ち（`ClientKey` 未設定）だけは TV 側の承認に最大 2 分かかるため、サイクルのウォッチドッグを適用しない。
 - **入力ソース判定（DDC/CI）**: 優先モニタが「今このPCを映しているか」は列挙有無では判別できない（USB-C/KVM モニタは別PC表示中も DP リンクを維持するため）。`IPreferredInputSourceProbe`（Windows: `DdcInputSourceProbe` が VCP 0x60 を読む）で都度判定し、`ThisPc`→online 扱い / `OtherSource`→offline 扱い / `Unknown`→列挙ベースへフォールバック、として同期判定に反映する。**この判定は同期の度に都度実行すること**（Mac への表示切替はディスプレイイベントを発火しないため、スナップショットに焼き込むと定期同期が誤って TV を奪う）。DDC は稀に失敗するのでリトライ＋直近確定値の保持で安定させる。
 - **TLS/ClientKey**:
   - webOS の自己署名証明書対策として `DefaultWebSocketTransport` は wss 証明書検証を緩和する仕様を維持する。
@@ -36,7 +37,7 @@
 - **ログ**: 状態遷移・実際の入力切替のみ Information。定常反復（`Already connected`/`already set; no switch`/SSDP の discover start・summary・final result・`No input mapping…skipping`）は Debug に留めてログ肥大を防ぐ。WebSocket 例外は Warning 1 行、詳細は Debug。**TV 到達不可（ネットワーク断・未検出/オフライン=`LgTvRegistrationException`）は正常運用でも起きるため、遷移時に一度だけ Warning、以降は Debug**（`_tvUnavailableLogged` で管理。復帰時に Information）。SSDP 探索は WSL/Tailscale 等の仮想 NIC を `SsdpInterfaceFilter` で除外する。
 
 ## テスト方針
-- Core: DisplaySyncWorker のオンライン/オフライン、stale 無視、冗長スイッチ抑止、例外スキップを UT で担保。
+- Core: DisplaySyncWorker のオンライン/オフライン、stale 無視、冗長スイッチ抑止、例外スキップを UT で担保。無応答 TV でのハング打ち切り（接続タイムアウト／サイクルのウォッチドッグ）も、ハングを再現する fake で UT 化する。
 - DisplayDetection.Windows: Win32MonitorEnumerator のトークン抽出・接続種別マッピングを UT。OS 依存部分は実機検証。
 - LgWebOsClient: レスポンスパーサーの正常/エラー/登録応答を UT。トランスポートはモック差し替え可能に。
 

--- a/src/LGTVSwitcher.Core/LgTv/LgTvSwitcherOptions.cs
+++ b/src/LGTVSwitcher.Core/LgTv/LgTvSwitcherOptions.cs
@@ -43,6 +43,20 @@ public sealed class LgTvSwitcherOptions
     public int SyncIntervalSeconds { get; set; }
 
     /// <summary>
+    /// LG TV への WebSocket 接続（TLS ハンドシェイクを含む）を打ち切るまでの秒数。0 以下は無効。
+    /// TV がスタンバイへ入ると TCP は張れても TLS 応答が返らないことがあり、
+    /// 上限が無いと接続ロックを握ったまま同期ループ全体が停止する。
+    /// </summary>
+    public int TvConnectTimeoutSeconds { get; set; } = 10;
+
+    /// <summary>
+    /// 同期 1 サイクル全体を打ち切るまでの秒数。0 以下は無効。
+    /// 接続後に TV が無応答になると送受信が返らないため、サイクルにも上限を設ける。
+    /// ペアリング待ち（<see cref="ClientKey"/> 未設定）の間は TV 側の承認に最大 2 分かかるため適用しない。
+    /// </summary>
+    public int SyncTimeoutSeconds { get; set; } = 30;
+
+    /// <summary>
     /// LG TV の切り替えをトリガーするモニタのフレンドリ名（またはデバイス名）。
     /// </summary>
     public string PreferredMonitorName { get; set; } = string.Empty;

--- a/src/LGTVSwitcher.Core/LgWebOs/Session/LgTvSession.cs
+++ b/src/LGTVSwitcher.Core/LgWebOs/Session/LgTvSession.cs
@@ -33,6 +33,7 @@ public sealed class LgTvSession : ILgTvSession
     private readonly LgTvResponseParser _responseParser;
     private readonly SemaphoreSlim _connectionLock = new(1, 1);
     private readonly SemaphoreSlim _requestLock = new(1, 1);
+    private readonly TimeSpan? _connectTimeout;
     private string? _activeHost;
     private string? _activeUsn;
     private bool _isRegistered;
@@ -53,6 +54,9 @@ public sealed class LgTvSession : ILgTvSession
         _responseParser = responseParser;
         _discoveryService = discoveryService;
         _clientKeyStore = clientKeyStore;
+        _connectTimeout = _options.TvConnectTimeoutSeconds > 0
+            ? TimeSpan.FromSeconds(_options.TvConnectTimeoutSeconds)
+            : null;
     }
 
     public async Task EnsureConnectedAsync(CancellationToken cancellationToken)
@@ -228,7 +232,30 @@ public sealed class LgTvSession : ILgTvSession
             await _transport.DisposeAsync().ConfigureAwait(false);
         }
 
-        await _transport.ConnectAsync(uri, cancellationToken).ConfigureAwait(false);
+        // TV がスタンバイへ入ると TCP は張れても TLS ハンドシェイクの応答が返らないことがある。
+        // ここに上限が無いと接続ロックを握ったまま返らず、同期ループ全体が停止する。
+        if (_connectTimeout is { } connectTimeout)
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(connectTimeout);
+
+            try
+            {
+                await _transport.ConnectAsync(uri, timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException ex) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                // 到達不可として扱い、呼び出し元で次の候補への切り替えと静かなリトライに載せる。
+                throw new LgTvRegistrationException(
+                    $"Timed out connecting to LG TV at {uri} after {connectTimeout.TotalSeconds:0.#}s.",
+                    ex);
+            }
+        }
+        else
+        {
+            await _transport.ConnectAsync(uri, cancellationToken).ConfigureAwait(false);
+        }
+
         _activeHost = endpoint.Host;
         _activeUsn = endpoint.Usn;
         _isRegistered = false;

--- a/src/LGTVSwitcher.Core/Workers/DisplaySyncWorker.cs
+++ b/src/LGTVSwitcher.Core/Workers/DisplaySyncWorker.cs
@@ -25,6 +25,7 @@ public sealed class DisplaySyncWorker : BackgroundService
     private readonly LgTvSwitcherOptions _options;
     private readonly string[] _allowedCurrentInputIds;
     private readonly TimeSpan? _syncInterval;
+    private readonly TimeSpan? _syncTimeout;
     private volatile DisplaySnapshot? _latestSnapshot;
 
     // TV 到達不可を Warning で通知したか。スリープ/オフ中に毎サイクル警告を出さないための遷移フラグ。
@@ -50,6 +51,9 @@ public sealed class DisplaySyncWorker : BackgroundService
             ?? Array.Empty<string>();
         _syncInterval = _options.SyncIntervalSeconds > 0
             ? TimeSpan.FromSeconds(_options.SyncIntervalSeconds)
+            : null;
+        _syncTimeout = _options.SyncTimeoutSeconds > 0
+            ? TimeSpan.FromSeconds(_options.SyncTimeoutSeconds)
             : null;
     }
 
@@ -126,11 +130,31 @@ public sealed class DisplaySyncWorker : BackgroundService
 
     private async Task TrySyncAsync(DisplaySnapshot snapshot, CancellationToken ct)
     {
+        // 接続後に TV が無応答になると送受信が返らず、1 サイクルが永久に返らない。
+        // ウォッチドッグで打ち切り、次サイクルで張り直す。
+        // ただしペアリング待ち（ClientKey 未設定）は TV 側の承認に最大 2 分かかるため適用しない。
+        var timeout = string.IsNullOrWhiteSpace(_options.ClientKey) ? null : _syncTimeout;
+
+        using var timeoutCts = timeout is null
+            ? null
+            : CancellationTokenSource.CreateLinkedTokenSource(ct);
+        if (timeout is { } watchdog)
+        {
+            timeoutCts!.CancelAfter(watchdog);
+        }
+
         try
         {
-            await SyncLgTvAsync(snapshot, ct).ConfigureAwait(false);
+            await SyncLgTvAsync(snapshot, timeoutCts?.Token ?? ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+        catch (OperationCanceledException ex) when (timeoutCts is { IsCancellationRequested: true })
+        {
+            // 応答が返らないのは到達不可と同じ扱いにして、ログを肥大させずに次サイクルで再試行する。
+            LogTvUnavailable(new TimeoutException(
+                $"LG TV sync did not complete within {timeout!.Value.TotalSeconds:0.#}s.",
+                ex));
+        }
         catch (Exception ex) when (IsTvUnavailable(ex))
         {
             LogTvUnavailable(ex);

--- a/src/LGTVSwitcher.Daemon.Windows/appsettings.json
+++ b/src/LGTVSwitcher.Daemon.Windows/appsettings.json
@@ -6,6 +6,8 @@
     "FallbackInputId": "HDMI_2",
     "AllowedCurrentInputIds": [],
     "SyncIntervalSeconds": 15,
+    "TvConnectTimeoutSeconds": 10,
+    "SyncTimeoutSeconds": 30,
     "PreferredMonitorName": "U2725QE",
     "PreferredMonitorThisPcInputSources": [ "DisplayPort" ]
   },

--- a/tests/LGTVSwitcher.Core.Tests/DisplaySyncWorkerTests.cs
+++ b/tests/LGTVSwitcher.Core.Tests/DisplaySyncWorkerTests.cs
@@ -736,6 +736,101 @@ public class DisplaySyncWorkerTests
         await worker.StopAsync(CancellationToken.None);
     }
 
+    // 接続後に TV が無応答になると送受信が返らない。ウォッチドッグで打ち切らないと同期ループが永久に止まる。
+    [Fact]
+    public async Task HangingQuery_ShouldBeAbortedByWatchdog_AndPipelineContinues()
+    {
+        var provider = new FakeSnapshotProvider();
+        var controller = new FakeLgTvController { HangingQueries = 1 };
+        var options = Options.Create(new LgTvSwitcherOptions
+        {
+            TargetInputId = "HDMI_4",
+            FallbackInputId = "HDMI_2",
+            PreferredMonitorName = "TEST",
+            ClientKey = "paired-key",
+            SyncTimeoutSeconds = 1,
+        });
+
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitForStart(provider);
+        await Task.Delay(100);
+
+        // 1 回目はハング → ウォッチドッグで打ち切られる
+        provider.Publish(CreateSnapshot(online: true));
+        await Task.Delay(2500);
+        Assert.Empty(controller.SwitchCalls);
+
+        // 打ち切り後もループが生きていれば、次のディスプレイ変化を処理できる
+        provider.Publish(CreateSnapshot(online: false));
+
+        var switched = await WaitForSwitchAsync(controller, call => call == "HDMI_2");
+        Assert.True(switched, "ウォッチドッグ後も同期ループは継続すべき。");
+
+        await worker.StopAsync(CancellationToken.None);
+    }
+
+    // ペアリング待ちは TV 側の承認に最大 2 分かかるため、ウォッチドッグで打ち切ってはならない。
+    [Fact]
+    public async Task HangingQuery_PairingPending_ShouldNotApplyWatchdog()
+    {
+        var provider = new FakeSnapshotProvider();
+        var controller = new FakeLgTvController { HangingQueries = int.MaxValue };
+        var options = Options.Create(new LgTvSwitcherOptions
+        {
+            TargetInputId = "HDMI_4",
+            FallbackInputId = "HDMI_2",
+            PreferredMonitorName = "TEST",
+            ClientKey = null,
+            SyncTimeoutSeconds = 1,
+        });
+
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitForStart(provider);
+        await Task.Delay(100);
+        provider.Publish(CreateSnapshot(online: true));
+
+        await Task.Delay(2500);
+
+        // 承認待ちが打ち切られていなければ、1 回目のクエリを掴んだまま
+        Assert.Equal(1, controller.QueryCalls);
+        Assert.Empty(controller.SwitchCalls);
+
+        await worker.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task HangingQuery_WatchdogDisabled_ShouldNotAbort()
+    {
+        var provider = new FakeSnapshotProvider();
+        var controller = new FakeLgTvController { HangingQueries = int.MaxValue };
+        var options = Options.Create(new LgTvSwitcherOptions
+        {
+            TargetInputId = "HDMI_4",
+            FallbackInputId = "HDMI_2",
+            PreferredMonitorName = "TEST",
+            ClientKey = "paired-key",
+            SyncTimeoutSeconds = 0,
+        });
+
+        using var worker = new DisplaySyncWorker(provider, controller, new NullPreferredInputSourceProbe(), options, NullLogger<DisplaySyncWorker>.Instance);
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitForStart(provider);
+        await Task.Delay(100);
+        provider.Publish(CreateSnapshot(online: true));
+
+        await Task.Delay(2500);
+
+        Assert.Equal(1, controller.QueryCalls);
+        Assert.Empty(controller.SwitchCalls);
+
+        await worker.StopAsync(CancellationToken.None);
+    }
+
     private sealed class FakeInputSourceProbe : IPreferredInputSourceProbe
     {
         public PreferredInputSource Result { get; set; } = PreferredInputSource.Unknown;
@@ -826,19 +921,29 @@ public class DisplaySyncWorkerTests
         public Exception? SwitchException { get; set; }
         public int QueryCalls { get; private set; }
 
+        /// <summary>先頭から何回のクエリをハングさせるか（接続後に TV が無応答になる状態の再現）。</summary>
+        public int HangingQueries { get; set; }
+
         public Task<string?> EnsureConnectedAsync(CancellationToken cancellationToken) => Task.FromResult<string?>(null);
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-        public Task<string?> GetCurrentInputAsync(CancellationToken cancellationToken)
+        public async Task<string?> GetCurrentInputAsync(CancellationToken cancellationToken)
         {
             QueryCalls++;
+
+            if (HangingQueries > 0)
+            {
+                HangingQueries--;
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+            }
+
             if (QueryException is not null)
             {
                 throw QueryException;
             }
 
-            return Task.FromResult(CurrentInput);
+            return CurrentInput;
         }
 
         public Task SwitchInputAsync(string inputId, CancellationToken cancellationToken)

--- a/tests/LGTVSwitcher.Core.Tests/LgTvSessionTests.cs
+++ b/tests/LGTVSwitcher.Core.Tests/LgTvSessionTests.cs
@@ -67,6 +67,71 @@ public sealed class LgTvSessionTests
         Assert.Equal("configured-tv.local", transport.ConnectUris[0].Host);
     }
 
+    // TV がスタンバイへ入ると TLS ハンドシェイクが返らないことがある。
+    // 上限が無いと接続ロックを握ったまま同期ループ全体が止まるため、必ず打ち切る。
+    [Fact]
+    public async Task EnsureConnectedAsync_ConnectHangs_TimesOutAndReportsUnavailable()
+    {
+        var transport = new FakeTransport { HangingConnects = 1 };
+        var discovery = new FakeDiscovery(new LgTvDiscoveryResult("192.168.0.20", null, "uuid:tv", "LG", "st"));
+        var options = Options.Create(new LgTvSwitcherOptions { TvConnectTimeoutSeconds = 1 });
+        var session = CreateSession(transport, discovery, new FakeClientKeyStore(), options);
+
+        // 打ち切りが効かないと戻らないため、テスト側にも上限を置いて失敗として顕在化させる。
+        var error = await Assert.ThrowsAsync<LgTvRegistrationException>(
+            () => session.EnsureConnectedAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10)));
+
+        Assert.Contains("Timed out connecting", error.InnerException?.Message ?? error.Message);
+        Assert.Single(transport.ConnectUris);
+        Assert.True(transport.DisposeCalls >= 1, "タイムアウト後はトランスポートを破棄して張り直せる状態にする。");
+    }
+
+    [Fact]
+    public async Task EnsureConnectedAsync_ConnectHangs_FallsBackToNextCandidate()
+    {
+        var transport = new FakeTransport { HangingConnects = 1 };
+        transport.Enqueue("""{"type":"registered","payload":{"client-key":"key-1"}}""");
+        var discovery = new FakeDiscovery(
+            new LgTvDiscoveryResult("192.168.0.10", "http://asleep-tv.local:3001/desc.xml", "uuid:asleep", "LG", "st"),
+            new LgTvDiscoveryResult("192.168.0.20", "http://awake-tv.local:3001/desc.xml", "uuid:awake", "LG", "st"));
+        var options = Options.Create(new LgTvSwitcherOptions { TvConnectTimeoutSeconds = 1 });
+        var session = CreateSession(transport, discovery, new FakeClientKeyStore(), options);
+
+        await session.EnsureConnectedAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(2, transport.ConnectUris.Count);
+        Assert.Equal("asleep-tv.local", transport.ConnectUris[0].Host);
+        Assert.Equal("awake-tv.local", transport.ConnectUris[1].Host);
+        Assert.Equal("key-1", options.Value.ClientKey);
+    }
+
+    // 停止要求によるキャンセルはタイムアウトではないため、登録例外に変換してはならない。
+    [Fact]
+    public async Task EnsureConnectedAsync_ConnectCancelledByCaller_ThrowsOperationCanceled()
+    {
+        var transport = new FakeTransport { HangingConnects = 1 };
+        var discovery = new FakeDiscovery(new LgTvDiscoveryResult("192.168.0.20", null, "uuid:tv", "LG", "st"));
+        var options = Options.Create(new LgTvSwitcherOptions { TvConnectTimeoutSeconds = 30 });
+        var session = CreateSession(transport, discovery, new FakeClientKeyStore(), options);
+        using var cts = new CancellationTokenSource(100);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => session.EnsureConnectedAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task EnsureConnectedAsync_ConnectTimeoutDisabled_UsesCallerToken()
+    {
+        var transport = new FakeTransport { HangingConnects = 1 };
+        var discovery = new FakeDiscovery(new LgTvDiscoveryResult("192.168.0.20", null, "uuid:tv", "LG", "st"));
+        var options = Options.Create(new LgTvSwitcherOptions { TvConnectTimeoutSeconds = 0 });
+        var session = CreateSession(transport, discovery, new FakeClientKeyStore(), options);
+        using var cts = new CancellationTokenSource(100);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => session.EnsureConnectedAsync(cts.Token));
+    }
+
     [Fact]
     public async Task DisposeAsync_IsIdempotent()
     {
@@ -150,13 +215,23 @@ public sealed class LgTvSessionTests
         public int RequestSendCount { get; private set; }
         public int DisposeCalls { get; private set; }
         public int MaxConcurrentRequests { get; private set; }
+
+        /// <summary>先頭から何回の接続をハングさせるか（TV スタンバイ時の TLS 無応答の再現）。</summary>
+        public int HangingConnects { get; set; }
+
         private int _activeRequests;
 
-        public Task ConnectAsync(Uri uri, CancellationToken cancellationToken)
+        public async Task ConnectAsync(Uri uri, CancellationToken cancellationToken)
         {
             ConnectUris.Add(uri);
+
+            if (HangingConnects > 0)
+            {
+                HangingConnects--;
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+            }
+
             State = WebSocketState.Open;
-            return Task.CompletedTask;
         }
 
         public Task SendAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)


### PR DESCRIPTION
## なぜ

実機で **3.5 日間、TV の入力切替が一切動いていなかった**。プロセスもディスプレイ検知も生きていて、ログには `Display snapshot changed` だけが出続けていたため、外からは正常に見えていた。

原因は同期ループのハング。ログの最後の行は接続開始の 1 行で、そこから先が無い:

```
2026-08-05 00:23:00.520 [INF] Connecting to LG TV at "wss://192.168.1.85:3001/"
（以降 3.5 日間、TV 関連のログはゼロ）
```

同じ時刻に張られた TCP が `Established` のまま 3.5 日残っていた:

```
Established  192.168.1.170:55165 -> 192.168.1.85:3001   CreationTime 2026/08/05 0:23:00
```

接続成功時に必ず出る `Ignoring TLS certificate error(s)` が出ていないので、**TCP は張れたが TLS ハンドシェイクの応答が返らないまま `ClientWebSocket.ConnectAsync` で止まっていた**（TV がスタンバイへ入った直後と推定）。ここに上限が無いと `LgTvSession` が `_connectionLock` を握ったまま返らず、debounce ループと 15 秒周期の定期同期の両方が止まる。一方でディスプレイ検知は別スレッドのメッセージループなので動き続ける——「プロセスは生きているのに切替だけ死ぬ」の正体。

同型のハング経路が `SendRequestCoreAsync` の `ReceiveStringAsync` にもある（上限があるのは登録応答待ちの 2 分だけ）。

## 設計判断

**A. 接続タイムアウトは `DefaultWebSocketTransport` ではなく `LgTvSession.ConnectTransportAsync` に置いた。**
トランスポート実装は `ExcludeFromCodeCoverage` で実 `ClientWebSocket` に張り付いており UT できない。セッション側に置けば `ILgTvWebSocketTransport` の fake でハングを再現でき、トランスポート実装が変わっても上限が効く。超過は `LgTvRegistrationException` に変換して、既存の「次候補へフォールバック」「`IsTvUnavailable` で静かにリトライ」の経路にそのまま載せている。

**B. サイクル全体のウォッチドッグも入れた（A だけでは足りない）。**
A が塞ぐのは接続だけで、接続後に無応答になる送受信のハングは残る。`TrySyncAsync` で linked CTS を張り、超過は TV 到達不可と同じ扱い（`_tvUnavailableLogged` で 1 回だけ Warning）にして次サイクルで張り直す。

**ペアリング待ちだけウォッチドッグの対象外にした。**
初回ペアリングは TV 側で承認するまで最大 2 分待つ設計で、30 秒で打ち切ると承認が間に合わず、毎サイクル TV にペアリング要求を出し続けて永久に完了しない。`ClientKey` 未設定のサイクルは適用しない。この間も A（10 秒）と登録待ちの 2 分上限が効くので、無制限には戻らない。

既定値は接続 10 秒 / サイクル 30 秒。定期同期が 15 秒周期なので、最悪でも 1 サイクル落として次で復旧する。

## 変更内容

- `LgTvSwitcherOptions`: `TvConnectTimeoutSeconds`（既定 10）、`SyncTimeoutSeconds`（既定 30）を追加。どちらも 0 以下で無効化できる
- `LgTvSession.ConnectTransportAsync`: 接続を linked CTS で打ち切り、`LgTvRegistrationException` に変換。呼び出し側のキャンセル（停止要求）は変換せずそのまま伝播
- `DisplaySyncWorker.TrySyncAsync`: サイクル全体のウォッチドッグ。ペアリング待ちは対象外
- `appsettings.json`: 新キーを既定値で明記
- `AGENTS.md`: 「タイムアウト（ハング防止）」を指針に追加（外すと再発するため）

## テストプラン

- `LgTvSessionTests` 4 本: タイムアウトで登録例外になる / 次候補へフォールバックする / 呼び出し側キャンセルは `OperationCanceledException` のまま / タイムアウト無効時は呼び出し側トークンで制御される
- `DisplaySyncWorkerTests` 3 本: ハングを打ち切った後もループが次の変化を処理できる / ペアリング待ちでは打ち切らない / ウォッチドッグ無効時は打ち切らない
- fake はキャンセル可能な無限待ち（`Task.Delay(Timeout.Infinite, ct)`）でハングを再現。**実装 2 ファイルを stash して新テストだけ流し、狙い通り 3 本が落ちることを確認済み**（残り 4 本は挙動不変を守るガード）
- `dotnet test lgtv-switcher.slnx` 全 125 本グリーン、警告 0

## 既知の制約

- `IPreferredInputSourceProbe.Probe()` は同期 API のため、DDC/CI 側でブロックした場合はウォッチドッグで割り込めない（DDC 側は既存のリトライで担保）
- ウォッチドッグはキャンセルを尊重するトランスポートが前提。`ClientWebSocket` は `ConnectAsync` / `ReceiveAsync` のキャンセルでソケットを abort するため成立する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkV6GU97r9y5p54k5C6iMQ
